### PR TITLE
Fix #2 by adding exit condition to loop in LSB search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,8 @@ readme = "README.md"
 [dependencies]
 serde = { version = "1.0.151", optional = true, features = ["derive"] }
 
+[dev-dependencies]
+ntest = "0.9"
+
 [features]
 serde = ["dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,4 +286,13 @@ mod tests {
             .into_iter()
             .for_each(|(prefix_sum, idx)| assert_eq!(fenwick_array.index_of(prefix_sum), idx))
     }
+
+    #[test]
+    #[ntest::timeout(1000)]
+    fn test_zero_array() {
+        // test for a regression where index_of in an array containing only 0 would loop endlessly
+        let f0: FenwickTree<usize> = FenwickTree::from([0]);
+        assert_eq!(f0.prefix_sum(0, 0), 0);
+        assert_eq!(f0.index_of(1), 1);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,10 @@ impl<T> FenwickTree<T> {
                     prefix_sum -= *value;
 
                     probe += half_lsb;
-                    continue;
+
+                    if half_lsb > 0 {
+                        continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
See title. If the LSB becomes 1 during the search, ``half_lsb`` will be zero, which will force the loop to continue forever, as the probe never changes.
This will also fix https://github.com/brurucy/indexset/issues/10