### PR TITLE
Optimize push method to be O(log(n)) instead of O(n)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,12 +162,11 @@ impl<T> FenwickTree<T> {
         let index = self.inner.len();
         self.inner.push(value);
 
-        for i in 0..index {
-            let parent = i | (i + 1);
-            let parent_val = self.inner[i];
-            if parent == index {
-                self.inner[index] += parent_val;
-            }
+        let lower_one_bits = (!index).trailing_zeros();
+        for i in 0..lower_one_bits {
+            let child = index & !(1 << i);
+            let child_val = self.inner[child];
+            self.inner[index] += child_val;
         }
     }
     /// Subtracts a difference from a given index.


### PR DESCRIPTION
Old push with 1 million elements took ~2 seconds (on my system)
New push with 1 million elements takes <1ms (on my system)

The children for a given `index` is `index` with each trailing consecutive 1 bit inverted. 

If it is unclear why this calculation works, it should become clear after looking at the output of this program which uses the previous brute-force approach:
```python
for i in range(0,100):
    children = []
    for j in range(0,100):
        if (j|(j+1)) == i:
            children.append(bin(j))
    print(f"Children of {bin(i)}: {children}")
```
```
Children of 0b0: []
Children of 0b1: ['0b0']
Children of 0b10: []
Children of 0b11: ['0b1', '0b10']
Children of 0b100: []
Children of 0b101: ['0b100']
Children of 0b110: []
Children of 0b111: ['0b11', '0b101', '0b110']
Children of 0b1000: []
Children of 0b1001: ['0b1000']
Children of 0b1010: []
Children of 0b1011: ['0b1001', '0b1010']
Children of 0b1100: []
Children of 0b1101: ['0b1100']
Children of 0b1110: []
Children of 0b1111: ['0b111', '0b1011', '0b1101', '0b1110']
Children of 0b10000: []
Children of 0b10001: ['0b10000']
Children of 0b10010: []
Children of 0b10011: ['0b10001', '0b10010']
Children of 0b10100: []
Children of 0b10101: ['0b10100']
Children of 0b10110: []
Children of 0b10111: ['0b10011', '0b10101', '0b10110']
Children of 0b11000: []
Children of 0b11001: ['0b11000']
Children of 0b11010: []
Children of 0b11011: ['0b11001', '0b11010']
Children of 0b11100: []
Children of 0b11101: ['0b11100']
Children of 0b11110: []
Children of 0b11111: ['0b1111', '0b10111', '0b11011', '0b11101', '0b11110']```